### PR TITLE
Boards: Add Lumenier Lux

### DIFF
--- a/js/boards.js
+++ b/js/boards.js
@@ -76,6 +76,10 @@ var BOARD_DEFINITIONS = [
         name: "MotoLab",
         identifier: "MOTO",
         vcp: true
+    }, {
+        name: "Lumenier Lux",
+        identifier: "LUX\0",
+        vcp: true
     }
 ];
 


### PR DESCRIPTION
Needed for good VCP reboot behaviour.

Note: Identifier on firmware side is only 3 chars which is bad practice since the MSP code assumes 4 byte length, luckily it's only 1 byte short so we get the null terminator instead of a random memory location. Probably not worth changing now since it's already in cleanflight and probably betaflight.
